### PR TITLE
Arduino 8bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # ArduinoRXInterrupt
+
+2017-12-23 -- I'm going to see if I can adapt this for Arduinos other than the Duo.
+
 Interrupt-driven PWM RC receiver handling for Arduino.  Handles up to eight channels. I have tested it on the Arduino Due with FrSky VD5M and D8R-XP receivers and on the Teensy 3.1 with the VD5M.
 
 To use, clone this folder to your Arduino/libraries folder.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # ArduinoRXInterrupt
 
-2017-12-23 -- I'm going to see if I can adapt this for Arduinos other than the Due. They obviously have less processing power than Due or Teensy, but might work for 1 or 2 channels. ?? The change I see right off hand is that Arduino interupt vector does not correspond with Pin numbers.
-
 Interrupt-driven PWM RC receiver handling for Arduino.  Handles up to eight channels. I have tested it on the Arduino Due with FrSky VD5M and D8R-XP receivers and on the Teensy 3.1 with the VD5M.
 
 To use, clone this folder to your Arduino/libraries folder.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ArduinoRXInterrupt
 
-2017-12-23 -- I'm going to see if I can adapt this for Arduinos other than the Duo.
+2017-12-23 -- I'm going to see if I can adapt this for Arduinos other than the Due. They obviously have less processing power than Due or Teensy, but might work for 1 or 2 channels. ?? The change I see right off hand is that Arduino interupt vector does not correspond with Pin numbers.
 
 Interrupt-driven PWM RC receiver handling for Arduino.  Handles up to eight channels. I have tested it on the Arduino Due with FrSky VD5M and D8R-XP receivers and on the Teensy 3.1 with the VD5M.
 

--- a/examples/TwoChannelUno/TwoChannelUno.ino
+++ b/examples/TwoChannelUno/TwoChannelUno.ino
@@ -1,0 +1,46 @@
+/*
+
+FiveChannelReadout : demo RXInterrupt with five-channel receiver.
+
+Copyright (C) Simon D. Levy 2015
+
+This file is part of RXInterrupt
+
+RXInterrupt is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as 
+published by the Free Software Foundation, either version 3 of the 
+License, or (at your option) any later version.
+
+RXInterrupt is distributed in the hope that it will be useful,     
+but WITHOUT ANY WARRANTY without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU Lesser General Public License 
+along with this code.  If not, see <http:#www.gnu.org/licenses/>.
+*/
+
+#include <RXInterrupt.h>
+
+void setup()
+{
+  // Aurduino based on ATmega328P or ATmega168 have external 
+  // interupts only on digital pins 2 & 3  
+  int pins[2] = {2, 3};
+
+  initChannels(pins, 2);
+
+  Serial.begin(9600);
+  Serial.println("Initialized pins 2 & 3");
+}
+            
+void loop()
+{
+  short values[2];
+
+  updateChannels(values, 2);
+  
+  Serial.print(values[0]);
+  Serial.print(" ");
+  Serial.print(values[1]);
+  Serial.println();
+}

--- a/src/RXInterrupt.cpp
+++ b/src/RXInterrupt.cpp
@@ -98,7 +98,11 @@ static void initChannel(void (*isrFun)(), int * pins, int chan, int nchans)
     nPins[chan] = pin;
 
     pinMode(pin, INPUT); 
-    attachInterrupt(pin, isrFun, CHANGE);
+    // For Due and Teensy, using just the raw pin number is okay
+    // but for most other Arduino microcontrollers, wrapping it
+    // in digitalPinToInterrupt will translate the pin to the 
+    // external interrupt vector.
+    attachInterrupt(digitalPinToInterrupt(pin), isrFun, CHANGE);
 }
 
 static void updateChannel(int off)


### PR DESCRIPTION
Adapted to work on 8-bit arduinos. Primarily added 'digitalPinToInterrupt' which should maintain transparent compatibility with Due and Teensy (but I have not tested.). digitalPinToInterrupt is designed to map the given Digital Pin ID to the internal interrupt vector available on a particular board.

I tested on Duemilanove (which is an old Arduino Board), Uno, and Mega and was able to get 2 channels of RC conversion. 